### PR TITLE
Fix ignite g container crash issue

### DIFF
--- a/App/Navigation/AppNavigation.js
+++ b/App/Navigation/AppNavigation.js
@@ -8,7 +8,7 @@ import NotLoggedInStackNavigator from './NotLoggedInStackNavigator'
 import styles from './Styles/NavigationStyles'
 
 // Manifest of possible screens
-export const PrimaryStackNavigator = StackNavigator({
+export const PrimaryNav = StackNavigator({
   LoadingScreen: { screen: LoadingScreen },
   LoggedInStack: { screen: LoggedInStackNavigator },
   NotLoggedInStack: { screen: NotLoggedInStackNavigator }
@@ -22,7 +22,7 @@ export const PrimaryStackNavigator = StackNavigator({
 
 const Navigation = ({ dispatch, navigation }) => {
   return (
-    <PrimaryStackNavigator
+    <PrimaryNav
       navigation={addNavigationHelpers({ dispatch, state: navigation })}
     />
   )

--- a/App/Redux/NavigationRedux.js
+++ b/App/Redux/NavigationRedux.js
@@ -1,8 +1,8 @@
 import { NavigationActions } from 'react-navigation'
-import { PrimaryStackNavigator } from '../Navigation/AppNavigation'
+import { PrimaryNav } from '../Navigation/AppNavigation'
 
 const { navigate, reset } = NavigationActions
-const { getStateForAction } = PrimaryStackNavigator.router
+const { getStateForAction } = PrimaryNav.router
 
 const INITIAL_STATE = getStateForAction(
   navigate({ routeName: 'LoadingScreen' })

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "babel-preset-react-native": "1.9.2",
     "enzyme": "^2.6.0",
     "husky": "^0.13.1",
-    "ignite-ir-boilerplate": "file:/Users/derekgreenberg/git/ignite-ir-boilerplate",
+    "ignite-ir-boilerplate": "^2.0.0-rc.6",
     "ignite-standard": "^1.0.0",
     "jest": "20.0.4",
     "mockery": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2414,8 +2414,9 @@ iconv-lite@~0.4.13:
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"
 
-"ignite-ir-boilerplate@file:/Users/derekgreenberg/git/ignite-ir-boilerplate":
+ignite-ir-boilerplate@^2.0.0-rc.6:
   version "2.0.0-rc.6"
+  resolved "https://registry.yarnpkg.com/ignite-ir-boilerplate/-/ignite-ir-boilerplate-2.0.0-rc.6.tgz#29525d6685c6bd0395d8cc97841404f36b3555d8"
   dependencies:
     ramda "^0.23.0"
 


### PR DESCRIPTION
Fixes ignite-ir-boilerplate error when running `ignite g container FooScreen` by renaming the primary StackNavigator to the expected name: 'PrimaryNav'.

Also updated dependencies to use ignite-ir-boilerplate ^2.0.0-rc.6' rather than a file path to my local copy of the ignite-ir-repo.